### PR TITLE
Fixes the 404 error when running the integration tests.

### DIFF
--- a/src/main/java/pt/bosch/heatingmonitor/web/fn/NotificationRouterConfig.java
+++ b/src/main/java/pt/bosch/heatingmonitor/web/fn/NotificationRouterConfig.java
@@ -14,7 +14,7 @@ import static org.springframework.web.reactive.function.server.RouterFunctions.r
 @RequiredArgsConstructor
 public class NotificationRouterConfig {
 
-    public static final String NOTIFICATION_PATH = "api/v1/notifications";
+    public static final String NOTIFICATION_PATH = "/api/v1/notifications";
     public static final String NOTIFICATION_PATH_ID = NOTIFICATION_PATH + "/{notificationId}";
 
     private final NotificationHandler handler;

--- a/src/main/java/pt/bosch/heatingmonitor/web/fn/SubscriptionRouterConfig.java
+++ b/src/main/java/pt/bosch/heatingmonitor/web/fn/SubscriptionRouterConfig.java
@@ -14,7 +14,7 @@ import static org.springframework.web.reactive.function.server.RouterFunctions.r
 @RequiredArgsConstructor
 public class SubscriptionRouterConfig {
 
-    public static final String SUBSCRIPTION_PATH = "api/v1/subscriptions";
+    public static final String SUBSCRIPTION_PATH = "/api/v1/subscriptions";
     public static final String SUBSCRIPTION_PATH_ID = SUBSCRIPTION_PATH + "/{subscriptionId}";
     public static final String SUBSCRIPTION_PATH_ACTIVE = SUBSCRIPTION_PATH + ":active";
     public static final String SUBSCRIPTION_PATH_ACTIVATE = SUBSCRIPTION_PATH_ID + ":activate";


### PR DESCRIPTION
## Description
There is an error in the tests where every request returns a 404 error, even though the endpoint exists. This occurred after the tests were already working.

## Explanation of changes
I had forgotten that add the forward slash to the uri.